### PR TITLE
Update license to be consistent with the JupyterLab license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,4 @@
-BSD 3-Clause License
-
-Copyright (c) 2019, JupyterLab
+Copyright (c) 2019 Project Jupyter Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This copies over the JupyterLab LICENSE file and changes the date to 2019.