### PR TITLE
Adding Code of Conduct to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # team-compass
 A repository for team interaction, syncing, and handling meeting notes across the JupyterLab ecosystem.
 
-# Weekly Developer Meeting
+## Weekly Developer Meeting
 Weekly Developer Meetings take place on [zoom](zoom.us/my/jupyter). Minutes will be taken at [Hackmd.io](https://hackmd.io/Uscrk0N1RhCtX-p6ZHUuWQ). Each week an issue will be opened with that week's meeting minutes and the issue from the previous week will be closed. 
+
+## Code of Conduct
+As an official Jupyter Project, all communication across all repositories in this organization should adhere to the [Project Jupyter Code of Conduct.](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md)


### PR DESCRIPTION
Per Jason's suggestion in #16 I am adding this to the README.md

If we want to merge this one I can close out the other.