### PR TITLE
Add time and date for the weekly meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A repository for team interaction, syncing, and handling meeting notes across the JupyterLab ecosystem.
 
 ## Weekly Developer Meeting
-Weekly Developer Meetings take place on [zoom](https://zoom.us/my/jovyan). Minutes will be taken at [Hackmd.io](https://hackmd.io/Y7fBMQPSQ1C08SDGI-fwtg). Each week an issue will be opened with that week's meeting minutes and the issue from the previous week will be closed. 
+Weekly Developer Meetings take place on [zoom](https://zoom.us/my/jovyan), on Wednesdays at UTC 16:00 ([your time](https://arewemeetingyet.com/UTC/2020-07-22/16:00/w/JupyterLab%20Weekly%20Meeting)). Minutes will be taken at [Hackmd.io](https://hackmd.io/Y7fBMQPSQ1C08SDGI-fwtg). Each week an issue will be opened with that week's meeting minutes and the issue from the previous week will be closed. 
 
 ## Code of Conduct
 As an official Jupyter Project, all communication across all repositories in this organization should adhere to the [Project Jupyter Code of Conduct.](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md)


### PR DESCRIPTION
To give a quick idea of when the next meeting is.

There is also a more general Jupyter Community calendar:

- on Discourse: https://discourse.jupyter.org/t/jupyter-community-calendar/2485
- https://jupyter.readthedocs.io/en/latest/community/content-community.html