### PR TITLE
Triage process draft

### DIFF
--- a/docs/triage-process.md
+++ b/docs/triage-process.md
@@ -1,5 +1,13 @@
 An issue that is **ready** can be picked up and worked on with high confidence that we will accept it into the project.
 
+# Triage process summary checklist
+
+- [ ] Read the item
+- [ ] Search the existing issues and mark it as a duplicate if necessary
+- [ ] If additional information is required, add a comment requesting it
+- [ ] If the item is ready to be worked on, assign it to a milestone
+- [ ] Apply appropriate labels to the item (see examples below)
+
 # Definition of ready
 
 **All requested information, where applicable, is provided.** From the templates in JupyterLab’s issues:

--- a/docs/triage-process.md
+++ b/docs/triage-process.md
@@ -34,10 +34,3 @@ Once triaged, if the item is ready, the reviewer should remove the `needs-triage
 
 With one hour or less of triage time per contributor per week, we should be able to triage all current and future issues in a timely manner. Our expectation is that every new item should be examined within a week of its creation.
 
-# Next steps
-
-Tag all current items in the issues list with `needs-triage`.
-
-Set recurring times to review items at a convenient time for each contributor.
-
-Track how many items are currently labeled with `needs-triage` and `needs-requester-info`, including the ages of each. Report on these metrics regularly such as at our weekly team meetings.

--- a/docs/triage-process.md
+++ b/docs/triage-process.md
@@ -26,11 +26,11 @@ For a **feature request**:
 
 # Triage process
 
-A bot will apply the `needs-triage` label to all new bugs and enhancement requests as they are filed. Existing items should also have this label applied as a one-time backfill.
+A bot applies the `Status: Needs Triage` label to all new bugs and enhancement requests as they are filed.
 
-On a regular basis, Jupyter contributors should review JupyterLab items tagged with `needs-triage`, starting with the oldest, and determine whether they meet the definition of ready.
+On a regular basis, Jupyter contributors should review JupyterLab items tagged with `Status: Needs Triage`, starting with the oldest, and determine whether they meet the definition of ready.
 
-Once triaged, if the item is ready, the reviewer should remove the `needs-triage` label; no additional label is required. If there is not enough information in the item as filed, the triage reviewer should apply the `needs-requester-info` label and leave `needs-triage` in place. If an item has remained in `needs-requester-info` for more than 14 days without any follow-up communication, it should be closed due to insufficient detail.
+Once triaged, if the item is ready, the reviewer should remove the `Status: Needs Triage` label; no additional label is required. If there is not enough information in the item as filed, the triage reviewer should apply the `Status: Needs Info` label and leave `Status: Needs Triage` in place. If an item has remained in `Status: Needs Info` for more than 14 days without any follow-up communication, the reviewer should apply `status: Blocked`. A blocked item should be closed after another 14 days pass without a reply that unblocks it.
 
 Our expectation is that every new item should be examined within a week of its creation.
 

--- a/docs/triage-process.md
+++ b/docs/triage-process.md
@@ -34,11 +34,11 @@ For a **feature request**:
 
 # Triage process
 
-A bot applies the `Status: Needs Triage` label to all new bugs and enhancement requests as they are filed.
+A bot applies the `status: Needs Triage` label to all new bugs and enhancement requests as they are filed.
 
-On a regular basis, Jupyter contributors should review JupyterLab items tagged with `Status: Needs Triage`, starting with the oldest, and determine whether they meet the definition of ready.
+On a regular basis, Jupyter contributors should review JupyterLab items tagged with `status: Needs Triage`, starting with the oldest, and determine whether they meet the definition of ready.
 
-Once triaged, if the item is ready, the reviewer should remove the `Status: Needs Triage` label; no additional label is required. If there is not enough information in the item as filed, the triage reviewer should apply the `Status: Needs Info` label and leave `Status: Needs Triage` in place. If an item has remained in `Status: Needs Info` for more than 14 days without any follow-up communication, the reviewer should apply `status: Blocked`. A blocked item should be closed after another 14 days pass without a reply that unblocks it.
+Once triaged, if the item is ready, the reviewer should remove the `status: Needs Triage` label; no additional label is required. If there is not enough information in the item as filed, the triage reviewer should apply the `status: Needs Info` label and leave `status: Needs Triage` in place. If an item has remained in `status: Needs Info` for more than 14 days without any follow-up communication, the reviewer should apply `status: Blocked`. A blocked item should be closed after another 14 days pass without a reply that unblocks it.
 
 Our expectation is that every new item should be examined within a week of its creation.
 

--- a/docs/triage-process.md
+++ b/docs/triage-process.md
@@ -1,0 +1,43 @@
+An issue that is **ready** can be picked up and worked on with high confidence that we will accept it into the project.
+
+# Definition of ready
+
+**All requested information, where applicable, is provided.** From the templates in JupyterLab’s issues:
+
+For a **bug**:
+
+* Description, preferably including screen shots
+* Steps to reproduce
+* Expected behavior
+* Context: OS, browser, JupyterLab version, relevant output
+
+For a **feature request**:
+
+* Description of the problem
+* Description of the proposed solution
+* Additional context
+
+**The item should represent real, relevant, feasible work**. In short, if a knowledgeable person were to be assigned this item, they would be able to complete it with a reasonable amount of effort and assistance, and it furthers the goals of the Jupyter project.
+
+* Issues should be unique; triage is the best time to identify duplicates.
+* Bugs represent valid expectations for use of Jupyter products and services.
+* Expectations for security, performance, accessibility, and localization match generally-accepted norms in the community that uses Jupyter products.
+* The item represents work that one developer can commit to owning, even if they collaborate with other developers for feedback. Excessively large items should be split into multiple items, each triaged individually, or into [team-compass](https://github.com/jupyterlab/team-compass) items to discuss more substantive changes.
+
+# Triage process
+
+A bot will apply the `needs-triage` label to all new bugs and enhancement requests as they are filed. Existing items should also have this label applied as a one-time backfill.
+
+On a regular basis, Jupyter contributors should review JupyterLab items tagged with `needs-triage`, starting with the oldest, and determine whether they meet the definition of ready.
+
+Once triaged, if the item is ready, the reviewer should remove the `needs-triage` label; no additional label is required. If there is not enough information in the item as filed, the triage reviewer should apply the `needs-requester-info` label and leave `needs-triage` in place. If an item has remained in `needs-requester-info` for more than 14 days without any follow-up communication, it should be closed due to insufficient detail.
+
+With one hour or less of triage time per contributor per week, we should be able to triage all current and future issues in a timely manner. Our expectation is that every new item should be examined within a week of its creation.
+
+# Next steps
+
+Tag all current items in the issues list with `needs-triage`.
+
+Set recurring times to review items at a convenient time for each contributor.
+
+Track how many items are currently labeled with `needs-triage` and `needs-requester-info`, including the ages of each. Report on these metrics regularly such as at our weekly team meetings.

--- a/docs/triage-process.md
+++ b/docs/triage-process.md
@@ -32,5 +32,5 @@ On a regular basis, Jupyter contributors should review JupyterLab items tagged w
 
 Once triaged, if the item is ready, the reviewer should remove the `needs-triage` label; no additional label is required. If there is not enough information in the item as filed, the triage reviewer should apply the `needs-requester-info` label and leave `needs-triage` in place. If an item has remained in `needs-requester-info` for more than 14 days without any follow-up communication, it should be closed due to insufficient detail.
 
-With one hour or less of triage time per contributor per week, we should be able to triage all current and future issues in a timely manner. Our expectation is that every new item should be examined within a week of its creation.
+Our expectation is that every new item should be examined within a week of its creation.
 


### PR DESCRIPTION
As discussed at the December 8, 2021 JupyterLab meeting, a proposal for triaging issues to ensure that we apply a consistent definition of "Ready" and to prevent issues from remaining open and non-actionable for long periods of time. I welcome your feedback and edits.