### PR TITLE
Add Jason Weill to the council

### DIFF
--- a/docs/team/contributors.yaml
+++ b/docs/team/contributors.yaml
@@ -92,5 +92,10 @@
   team: active
   last-check-in: 2022-03
 
+- name: Jason Weill
+  handle: "@jweill-aws"
+  affiliation: Amazon Web Services
+  team: active
+  last-check-in: 2022-07
 
 # Inactive council members at the end, also alphabetical


### PR DESCRIPTION
Jason Weill has agreed to join the JupyterLab Council.

Preview on ReadTheDocs: https://jupyterlab-team-compass--153.org.readthedocs.build/en/153/team.html