### PR TITLE
Add host script/guide.

### DIFF
--- a/docs/host_guide.rst
+++ b/docs/host_guide.rst
@@ -59,7 +59,7 @@ info about that HERE [LINK/TODO].
 - Record the meeting. The host starts and stops the recording. These are
 posted to YouTube for the community to view.
 - Try to keep meeting minutes on the collaborative HackMD document [LINK/TODO]
-- Provide a signal ("Brace yourselfes") when starting stopping recording
+- Provide a signal ("Brace yourselfes") when starting/stopping recording
 - Kick unwelcome recording bots: Per the Jupyter community page, participants
   should not record meetings on their own. The host should ask participants
   that look like AI recording bots:

--- a/docs/host_guide.rst
+++ b/docs/host_guide.rst
@@ -43,9 +43,11 @@ Host Responsibilities
 First and foremost, the host should facilitate the flow of a meeting. That means:
 
 - Going through the agenda
+  - Do time checks/pause + move on to hit all items when there are time concerns
 - Guiding discussion
 - Making sure everyone has a chance to speak
 - Maintaining order
+- Mention/link to the Jupyter Code of Conduct and how everyone is bound to it
 
 The host should also:
 

--- a/docs/host_guide.rst
+++ b/docs/host_guide.rst
@@ -59,7 +59,7 @@ info about that HERE [LINK/TODO].
 - Record the meeting. The host starts and stops the recording. These are
 posted to YouTube for the community to view.
 - Try to keep meeting minutes on the collaborative HackMD document [LINK/TODO]
-- Provide a signal ("Brace yourselfes") when starting/stopping recording
+- Provide a signal ("Brace yourselves") when starting/stopping recording
 - Kick unwelcome recording bots: Per the Jupyter community page, participants
   should not record meetings on their own. The host should ask participants
   that look like AI recording bots:
@@ -78,7 +78,7 @@ Pre-Meeting Prep
 
 Log in to Zoom from the Project Jupyter account. Request access HERE [LINK/TODO]
 if needed. Make sure you have a stable internet connection, a good quality
-microphone, and a quiet environment. 
+microphone, and a quiet environment.
 
 Check the meeting agenda on HackMD. The agenda is a collaboratively created
 document made by the participants. Ensure a section for today's meeting is

--- a/docs/host_guide.rst
+++ b/docs/host_guide.rst
@@ -67,7 +67,8 @@ posted to YouTube for the community to view.
     - If they get no response from the account, the host should assume it's
       recording, and remove it from the meeting.
 
-Last, keep in mind that the code of conduct applies to hosts too!
+Last, keep in mind that the code of conduct applies to hosts too! Hosts should
+peruse and follow the Jupyter Code of conduct.
 
 Meeting Script and Checklist
 ----------------------------

--- a/docs/host_guide.rst
+++ b/docs/host_guide.rst
@@ -60,6 +60,12 @@ info about that HERE [LINK/TODO].
 posted to YouTube for the community to view.
 - Try to keep meeting minutes on the collaborative HackMD document [LINK/TODO]
 - Provide a signal ("Brace yourselfes") when starting stopping recording
+- Kick unwelcome recording bots: Per the Jupyter community page, participants
+  should not record meetings on their own. The host should ask participants
+  that look like AI recording bots:
+    - To identify themselves and state whether they're recording
+    - If they get no response from the account, the host should assume it's
+      recording, and remove it from the meeting.
 
 Last, keep in mind that the code of conduct applies to hosts too!
 

--- a/docs/host_guide.rst
+++ b/docs/host_guide.rst
@@ -1,0 +1,142 @@
+Host Guide (for Weekly Meetings)
+================================
+
+Welcome to the Host Guide, a place for weekly call hosts to get help,
+info, advice and best practices for conducting great, fun, effective
+weekly meetings.
+
+Check the Suggested Meeting Script section if you want a TL;DR for quick
+tips to follow for running a great meeting, and peruse the other sections
+for basic info and additional context.
+
+Basic Meeting Event Info
+------------------------
+
+JupyterLab team meetings are held every Wednesday. You can check the Jupyter Community
+Meetings calendar [LINK/TODO] for the exact time in your timezone.
+
+HACKMD link/info here TODO.
+
+Meeting Purpose/Goals
+---------------------
+
+The weekly meetings are a way to connect JupyterLab contributors and the
+community, so (ideally) all participants should have a good time, feel welcome,
+and be heard. In line with that:
+
+Meetings should be...
+- Positive, friendly, exciting
+- Welcoming and open to JupterLab users from diverse backgrounds
+- Newcomers in particular should be welcomed and encouraged to
+  chime in and discuss, or participate in whatever way they would like
+
+Topics
+^^^^^^
+
+Weekly meetings are for contributors to discuss features, ideas, PRs and other
+work on JupyterLab, and for the community to discuss their work, connect
+with JupyterLab contributors, seek help, and more.
+
+Host Responsibilities
+---------------------
+
+First and foremost, the host should facilitate the flow of a meeting. That means:
+
+- Going through the agenda
+- Guiding discussion
+- Making sure everyone has a chance to speak
+- Maintaining order
+
+The host should also:
+
+- Try to log in as the “Project Jupyter” host account during meetings so they
+can manage the meeting (kicking spammers, muting and recording, etc.), more
+info about that HERE [LINK/TODO].
+- Record the meeting. The host starts and stops the recording. These are
+posted to YouTube for the community to view.
+- Try to keep meeting minutes on the collaborative HackMD document [LINK/TODO]
+
+Last, keep in mind that the code of conduct applies to hosts too!
+
+Meeting Script and Checklist
+----------------------------
+
+Pre-Meeting Prep
+^^^^^^^^^^^^^^^^
+
+Log in to Zoom from the Project Jupyter account. Request access HERE [LINK/TODO]
+if needed. Make sure you have a stable internet connection, a good quality
+microphone, and a quiet environment. 
+
+Check the meeting agenda on HackMD. The agenda is a collaboratively created
+document made by the participants. Ensure a section for today's meeting is
+created, with today's date and a table for participants to record their names
+(which can be copied/pasted from lower entries). The agenda will also be used
+as meeting minutes.
+
+At the start of the meeting
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Hello and welcome to our [day, month, year] Jupyter community call. I’m
+[host name] and I’ll be your host today.
+
+This is a place to for JupyterLab contributors to connect with each other
+and the community about JupyterLab topics. We want all newcomers to feel
+welcome, so please feel free to jump in on discussions, introduce yourself,
+or add your own items to the agenda.
+
+There’s a couple things to know while you are here.
+
+First, I want to remind everyone that community calls will be recorded and
+posted to YouTube for the community to view. Please keep that in mind while
+you’re here.
+
+Second, I’d like to remind people that as this is a part of the Jupyter
+community we are all held to the Jupyter Code of Conduct. You can read about 
+the code of conduct at jupyter.org/conduct.
+
+If you haven’t been here before, here’s how this works. Presenters have
+submitted what they want to share ahead of time and can be found on the
+agenda. We’ll have a little time for discussion with each one.
+
+Starting the agenda
+^^^^^^^^^^^^^^^^^^^
+
+[Prepare to start the recording]
+Okay, before we start the recording, does anyone have anything they'd like
+to say off the record? (Say "Brace Yourselves!" before starting/stopping
+recording :)
+
+[After the recording ends]
+If you have anything to say off the record, please feel free to discuss
+that now.
+
+Near the end of the call
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Thank you to everyone presenting and attending! I’m happy to have you all as a part
+of the Jupyter community.
+
+If you have any feedback, please direct it at [platform/link]. I’d love to hear what
+you think about the call.
+
+Our next community call will be [day, month]. Check out the Jupyter community calendar
+to see what other types of meetings 
+are happening in between.
+
+If you have any interest in sharing in future community calls, please do! It doesn’t
+have to be a big share, a polished share, or a technical share, just show off what
+you do with Jupyter that excites you. Submit topics here [platform/link].
+
+If you’re interested in hosting a community call, feel free to reach out. It would be
+great to get different people interacting with the community.
+
+After the Meeting
+^^^^^^^^^^^^^^^^^
+
+Finalize meeting minutes: Go back to HackMD and make any needed additions,
+corrections and formatting you can.
+
+Publish the minutes: Convert the HackMD document to markdown and publish
+it to the relevant Weekly Team Meetings thread on GitHub [LINK/TODO] in the
+JupyterLab team-compass repository on the corresponding thread.

--- a/docs/host_guide.rst
+++ b/docs/host_guide.rst
@@ -89,27 +89,27 @@ as meeting minutes.
 At the start of the meeting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Hello and welcome to our [day, month, year] Jupyter community call. I’m
-[host name] and I’ll be your host today.
+Hello and welcome to our [day, month, year] Jupyter community call. I'm
+[host name] and I'll be your host today.
 
 This is a place to for JupyterLab contributors to connect with each other
 and the community about JupyterLab topics. We want all newcomers to feel
 welcome, so please feel free to jump in on discussions, introduce yourself,
 or add your own items to the agenda.
 
-There’s a couple things to know while you are here.
+There's a couple things to know while you are here.
 
 First, I want to remind everyone that community calls will be recorded and
 posted to YouTube for the community to view. Please keep that in mind while
-you’re here.
+you're here.
 
-Second, I’d like to remind people that as this is a part of the Jupyter
+Second, I'd like to remind people that as this is a part of the Jupyter
 community we are all held to the Jupyter Code of Conduct. You can read about 
 the code of conduct at jupyter.org/conduct.
 
-If you haven’t been here before, here’s how this works. Presenters have
+If you haven't been here before, here's how this works. Presenters have
 submitted what they want to share ahead of time and can be found on the
-agenda. We’ll have a little time for discussion with each one.
+agenda. We'll have a little time for discussion with each one.
 
 Starting the agenda
 ^^^^^^^^^^^^^^^^^^^
@@ -126,21 +126,21 @@ that now.
 Near the end of the call
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Thank you to everyone presenting and attending! I’m happy to have you all as a part
+Thank you to everyone presenting and attending! I'm happy to have you all as a part
 of the Jupyter community.
 
-If you have any feedback, please direct it at [platform/link]. I’d love to hear what
+If you have any feedback, please direct it at [platform/link]. I'd love to hear what
 you think about the call.
 
 Our next community call will be [day, month]. Check out the Jupyter community calendar
 to see what other types of meetings 
 are happening in between.
 
-If you have any interest in sharing in future community calls, please do! It doesn’t
+If you have any interest in sharing in future community calls, please do! It doesn't
 have to be a big share, a polished share, or a technical share, just show off what
 you do with Jupyter that excites you. Submit topics here [platform/link].
 
-If you’re interested in hosting a community call, feel free to reach out. It would be
+If you're interested in hosting a community call, feel free to reach out. It would be
 great to get different people interacting with the community.
 
 After the Meeting

--- a/docs/host_guide.rst
+++ b/docs/host_guide.rst
@@ -33,8 +33,8 @@ Meetings should be...
 Topics
 ^^^^^^
 
-Weekly meetings are for contributors to discuss features, ideas, PRs and other
-work on JupyterLab, and for the community to discuss their work, connect
+Weekly meetings are for contributors to discuss features, demos, ideas, PRs and
+any other work on JupyterLab, and for the community to discuss their work, connect
 with JupyterLab contributors, seek help, and more.
 
 Host Responsibilities

--- a/docs/host_guide.rst
+++ b/docs/host_guide.rst
@@ -57,6 +57,7 @@ info about that HERE [LINK/TODO].
 - Record the meeting. The host starts and stops the recording. These are
 posted to YouTube for the community to view.
 - Try to keep meeting minutes on the collaborative HackMD document [LINK/TODO]
+- Provide a signal ("Brace yourselfes") when starting stopping recording
 
 Last, keep in mind that the code of conduct applies to hosts too!
 

--- a/docs/host_guide.rst
+++ b/docs/host_guide.rst
@@ -45,7 +45,9 @@ First and foremost, the host should facilitate the flow of a meeting. That means
 - Going through the agenda
   - Do time checks/pause + move on to hit all items when there are time concerns
 - Guiding discussion
+  - Read chats aloud for participants + the recording
 - Making sure everyone has a chance to speak
+  - Interject when someone has their hand raised
 - Maintaining order
 - Mention/link to the Jupyter Code of Conduct and how everyone is bound to it
 


### PR DESCRIPTION
In the Lab weekly meeting, participants discussed creating a new script for hosts to follow to ensure fun, effective, high quality weekly meetings. This draft offers a solution. This is based off of [Isabella's Host Script](https://github.com/isabela-pf/jupyter-communitycalls/blob/main/host-guidelines.md) template, and existing work by some JupyterLab community members.

Issue:
- https://github.com/jupyter/docs-team-compass/issues/26