### PR TITLE
Add members from the Notebook council

### DIFF
--- a/docs/team/contributors.yaml
+++ b/docs/team/contributors.yaml
@@ -90,11 +90,6 @@
   affiliation: Quantstack
   last-check-in: "Thu 16 Nov 2023"
 
-- name: Kevin Goldsmith
-  handle: "@kevingoldsmith"
-  affiliation: Anaconda
-  last-check-in: "Thu 16 Nov 2023"
-
 - name: Michał Krassowski
   handle: "@krassowski"
   affiliation: Quansight

--- a/docs/team/contributors.yaml
+++ b/docs/team/contributors.yaml
@@ -90,6 +90,11 @@
   affiliation: Quantstack
   last-check-in: "Thu 16 Nov 2023"
 
+- name: Kevin Goldsmith
+  handle: "@kevingoldsmith"
+  affiliation: Anaconda
+  last-check-in: "Thu 16 Nov 2023"
+
 - name: Michał Krassowski
   handle: "@krassowski"
   affiliation: Quansight
@@ -108,5 +113,20 @@
 - name: R Ely
   handle: "@ohrely"
   affiliation: Bloomberg
+  last-check-in: "Thu 16 Nov 2023"
+
+- name: Rosio Reyes
+  handle: "@RRosio"
+  affiliation: Anaconda
+  last-check-in: "Thu 16 Nov 2023"
+
+- name: Sylvain Corlay
+  handle: "@SylvainCorlay"
+  affiliation: QuantStack
+  last-check-in: "Thu 16 Nov 2023"
+
+- name: Zach Sailer
+  handle: "@Zsailer"
+  affiliation: Apple
   last-check-in: "Thu 16 Nov 2023"
 


### PR DESCRIPTION
Part of #230 and as a follow-up to https://github.com/jupyter/governance/pull/200

Add members from the previous Notebook council.

This results in 4 new members to be added to the list (others are already part of the JupyterLab council):

- [ ] @kevingoldsmith
- [x] @RRosio 
- [x] @SylvainCorlay
- [x] @Zsailer

Could you reply here to confirm it is ok for you to be added to the Jupyter Frontends council as the result of the https://github.com/jupyter/governance/pull/200? Thanks!