### PR TITLE
Update the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JupyterLab team-compass
+# Jupyter Frontends team-compass
 
 A repository for team interaction, syncing, and handling meeting notes across the JupyterLab ecosystem.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Team Compass'
-copyright = '2021, JupyterLab'
+copyright = '2024, JupyterLab'
 author = 'JupyterLab Team'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/team.md
+++ b/docs/team.md
@@ -1,4 +1,4 @@
-# Current Jupyter Jupyter Frontends Council members
+# Current Jupyter Frontends Council members
 
 This page lists (in random order) the officially named Jupyter Frontends Council members.
 

--- a/docs/team.md
+++ b/docs/team.md
@@ -1,8 +1,8 @@
-# Current Jupyter Frontends Council members
+# Current Jupyter Jupyter Frontends Council members
 
-This page lists (in random order) the officially named Frontends Council members.
+This page lists (in random order) the officially named Jupyter Frontends Council members.
 
-Council members are actively participating in the development, maintenance, planning, and discussion around projects in the JupyterLab Github organization.
+Council members are actively participating in the development, maintenance, planning, and discussion around projects in the JupyterLab Github organization and the Jupyter Notebook project.
 
 ```{eval-rst}
 

--- a/docs/team.md
+++ b/docs/team.md
@@ -1,6 +1,6 @@
-# Current JupyterLab Council members
+# Current Jupyter Frontends Council members
 
-This page lists (alphabetically) the officially named JupyterLab Council members.
+This page lists (in random order) the officially named Frontends Council members.
 
 Council members are actively participating in the development, maintenance, planning, and discussion around projects in the JupyterLab Github organization.
 
@@ -13,6 +13,6 @@ Council members are actively participating in the development, maintenance, plan
 
 ## Software Steering Council Representative
 
-Each *official* subproject in Jupyter gets a single [Software Steering Council Representative](https://jupyter.org/governance/software_steering_council.html#software-steering-council). JupyterLab's representative is elected by the members. This representative *should* be re-elected every year (i.e. in January).
+Each *official* subproject in Jupyter gets a single [Software Steering Council Representative](https://jupyter.org/governance/software_steering_council.html#software-steering-council). Frontends representative is elected by the members. This representative *should* be re-elected every year (i.e. in January).
 
-The current representative is Frédéric Collonval.
+The current representative is Jérémy Tuloup.

--- a/docs/team/becoming-member.md
+++ b/docs/team/becoming-member.md
@@ -1,17 +1,17 @@
-# Becoming a JupyterLab Council member
+# Becoming a Jupyter Frontends Council member
 
-This document describes how to become a council member. It includes information about the two subgroups of JupyterLab Council members:
+This document describes how to become a council member. It includes information about the two subgroups of Jupyter Frontends Council members:
 - The release group (see [Release team member](#release-team-member))
 - The admin group (see [Admin team member](#admin-team-member))
 
-## JupyterLab Council member
+## Jupyter Frontends Council member
 
-### JupyterLab Council responsibilities
+### Jupyter Frontends Council responsibilities
 
 Members actively carry out the responsibilities listed in the [Membership Guide Page](membership_guidelines):
 
 * Must be nominated by a current member.
-* Can be elected as the Software Steering Council representative for JupyterLab.
+* Can be elected as the Software Steering Council representative for Jupyter Frontends.
 * Get a vote in a voting situation.
 * Count towards quorum in a voting situation.
 * Are expected to participate in a 2/3 of votes (through a year).
@@ -21,7 +21,7 @@ Members actively carry out the responsibilities listed in the [Membership Guide 
 
 ### Nominating a new member
 
-For someone to become a JupyterLab Council member, they should already be a consistent,
+For someone to become a Jupyter Frontends Council member, they should already be a consistent,
 positive, productive member of the community. Newcomers are encouraged to
 become members after they've shown a sustained interest in
 engaging with the community. Moreover, council members should be interested in
@@ -30,28 +30,28 @@ putting in more time and effort than non-members. This doesn't have to
 mean contributing code - it can be assisting others in forums/issues, reviewing
 pull requests, participating in team meetings, etc.
 
-Any new members must be nominated and championed by an active JupyterLab Council member.
+Any new members must be nominated and championed by an active Jupyter Frontends Council member.
 This process takes the following steps:
 
-1. The champion should first discuss internally with the JupyterLab Council to
+1. The champion should first discuss internally with the Jupyter Frontends Council to
    ensure that there's general consensus before officially starting
    the process.
-2. If there is obvious consensus within the JupyterLab Council, then move to the
+2. If there is obvious consensus within the Jupyter Frontends Council, then move to the
    next step. If not, then an internal vote can be taken to protect the privacy
    of the potential member.
-3. A member of the JupyterLab Council contacts the potential new member and asks
+3. A member of the Jupyter Frontends Council contacts the potential new member and asks
    if they are interested. Don't forget to run them by the {ref}`membership_guidelines`
    page to make sure they understand what they're signing up for.
 
 ### Membership maintenance
 
-Every six months, a bot will open an issue in the [council repo](https://github.com/jupyterlab/council) asking all currently active JupyterLab council team members to reply within three weeks if they still consider themselves active. If a team member replies no, they will be removed from the council. If a member does not reply, the council may reach that member personally for membership confirmation. If that request for confirmation is not answered within a month, the member will be removed from the council.
+Every six months, a bot will open an issue in the [council repo](https://github.com/jupyterlab/council) asking all currently active Jupyter Frontends Council team members to reply within three weeks if they still consider themselves active. If a team member replies no, they will be removed from the council. If a member does not reply, the council may reach that member personally for membership confirmation. If that request for confirmation is not answered within a month, the member will be removed from the council.
 
 ## Release team member
 
 ### Joining the release team
 
-Any JupyterLab Council member can ask to be part of the release team using the weekly call, chat, or official council email list.
+Any Jupyter Frontends Council member can ask to be part of the release team using the weekly call, chat, or official council email list.
 
 > Private channel is recommended to limit the exposure of such information for security reason.
 
@@ -76,7 +76,7 @@ Every six months, a bot will open an issue in the [council repo](https://github.
 
 ### Joining the admin team
 
-Any JupyterLab Council member can ask to be part of the admin team using the weekly call, chat, or official council email list.
+Any Jupyter Frontends Council member can ask to be part of the admin team using the weekly call, chat, or official council email list.
 
 > Private channel is recommended to limit the exposure of such information for security reason.
 
@@ -94,7 +94,7 @@ Admin team members will be added to the following groups:
 - NPM jupyterlab organization: [owners](https://www.npmjs.com/settings/jupyterlab)
 - conda-forge jupyterlab recipe: maintainer rights
 
-Administrators maintain membership of the groups listed above as well as the JupyterLab council and release team.
+Administrators maintain membership of the groups listed above as well as the Jupyter Frontends Council and release team.
 
 ### Membership maintenance
 

--- a/docs/team/contributors.yaml
+++ b/docs/team/contributors.yaml
@@ -72,7 +72,7 @@
 
 - name: Frederic Collonval
   handle: "@fcollonval"
-  affiliation: QuantStack
+  affiliation: WebScIT
   last-check-in: "Thu 15 Feb 2024"
 
 - name: Fernando Perez

--- a/docs/team/decision-making.md
+++ b/docs/team/decision-making.md
@@ -1,11 +1,11 @@
 # How decisions are made
 
-The JupyterLab Council follows the ["Decision Making" Guidelines](https://jupyter.org/governance/decision_making.html#required-aspects-of-decision-making) described in the main Jupyter governance documents.
+The Jupyter Frontends Council follows the ["Decision Making" Guidelines](https://jupyter.org/governance/decision_making.html#required-aspects-of-decision-making) described in the main Jupyter governance documents.
 
 In short, we'll first seek an informal consensus. If a clear consensus cannot be reached, an active council member can call for a vote. The voting process then follows the guidelines laid out by the [Jupyter Governance model]((https://jupyter.org/governance/decision_making.html#required-aspects-of-decision-making)).
 
-## JupyterLab Council size
+## Jupyter Frontends Council size
 
-There is no limit to the size of the JupyterLab Council. We follow the [guidelines laid out](https://jupyter.org/governance/bootstrapping_decision_making.html#bootstrapping-decision-making-bodies) by the broader Jupyter governance model which encourages a large, highly participatory decision body:
+There is no limit to the size of the Jupyter Frontends Council. We follow the [guidelines laid out](https://jupyter.org/governance/bootstrapping_decision_making.html#bootstrapping-decision-making-bodies) by the broader Jupyter governance model which encourages a large, highly participatory decision body:
 
 > The new governance model and decision-making guide is designed to support large, highly participatory decision-making bodies. As such, even Subprojects that have a clear decision-making body today may wish to increase the size of that body to include more contributors.

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -2,7 +2,7 @@
 
 # Membership guidelines
 
-This page holds resources for members of the JupyterLab Council.
+This page holds resources for members of the Jupyter Frontends Council.
 They're meant to guide members to be happy, productive members of the team!
 
 ## What are the team resources?
@@ -10,11 +10,11 @@ They're meant to guide members to be happy, productive members of the team!
 There are a few resources that are particularly useful for team members. Here's
 a quick list to get you started.
 
-* [**The JupyterLab Team Compass**](https://github.com/jupyterlab/team-compass)
+* [**The Jupyter Frontends Team Compass**](https://github.com/jupyterlab/team-compass)
   is a repository with lots of information about team-related things. It has
   development tips, information about team meetings, milestones and roadmaps,
   etc.
-* [**The JupyterLab Team Compass issues**](https://github.com/jupyterlab/team-compass/issues)
+* [**The Jupyter Frontends Team Compass issues**](https://github.com/jupyterlab/team-compass/issues)
   are where we often discuss specific, actionable things related to the *team*
   (e.g., discussing whether to change something in the team-compass repo).
 
@@ -29,7 +29,7 @@ In this respect, we are using:
 2. The [Discourse forum](https://discourse.jupyter.org/) for general discussions, support
 questions, or just as a place where we can inspire each other.
 3. The [Gitter channel](https://app.gitter.im/#/room/#jupyterlab_jupyterlab:gitter.im) for discussions and support questions.
-4. The [JupyterLab council mailing list](https://groups.google.com/u/1/g/jupyterlab-council) for discussing membership, none-public questions,... .
+4. The [Jupyter Frontends Council mailing list](https://groups.google.com/u/1/g/jupyterlab-council) for discussing membership, none-public questions,... .
 
 ## How can I help?
 
@@ -79,7 +79,7 @@ Having merge rights is both a privilege and a responsibility - please be
 thoughtful when using it! To that extent, here are a few guidelines when
 deciding to merge things into one of our repositories:
 
-* **Use your best judgment**. As a member of the JupyterLab Council, we trust
+* **Use your best judgment**. As a member of the Jupyter Frontends Council, we trust
   your judgment, and we ask you to use your best judgment in deciding when to
   take an action.
 * **Make sure it's quality code**. We know this is somewhat subjective, but


### PR DESCRIPTION
This update the documentation to reflect the merge of JupyterLab council with the notebook council within a new Jupyter Frontends council